### PR TITLE
Use `HttpClient` instead of `WebRequest`

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,6 +6,7 @@
     <PackageVersion Include="JetBrains.Annotations" Version="2021.3.0" />
     <PackageVersion Include="MetaBrainz.Common.Json" Version="5.0.0" />
     <PackageVersion Include="System.Drawing.Common" Version="4.7.0" />
+    <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="System.Text.Json" Version="6.0.0" />
   </ItemGroup>
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
   <ItemGroup>
     <PackageVersion Include="JetBrains.Annotations" Version="2021.3.0" />
     <PackageVersion Include="MetaBrainz.Common.Json" Version="5.0.0" />
-    <PackageVersion Include="System.Drawing.Common" Version="4.7.0" />
+    <PackageVersion Include="System.Drawing.Common" Version="6.0.0" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="System.Text.Json" Version="6.0.0" />
   </ItemGroup>

--- a/MetaBrainz.MusicBrainz.CoverArt/CoverArtImage.cs
+++ b/MetaBrainz.MusicBrainz.CoverArt/CoverArtImage.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Drawing;
 using System.IO;
+using System.Runtime.Versioning;
 
 using JetBrains.Annotations;
 
@@ -35,6 +36,10 @@ public sealed class CoverArtImage : IDisposable {
   /// <exception cref="ArgumentException">
   /// When the image data is not valid (or not supported by the <see cref="System.Drawing.Image"/> class).
   /// </exception>
+  /// <remarks>This method only </remarks>
+#if NET
+  [SupportedOSPlatform("windows")]
+#endif
   public Image Decode(bool useEmbeddedColorManagement = false, bool validateImageData = false)
     => Image.FromStream(this.Data, useEmbeddedColorManagement, validateImageData);
 

--- a/MetaBrainz.MusicBrainz.CoverArt/CoverArtImage.cs
+++ b/MetaBrainz.MusicBrainz.CoverArt/CoverArtImage.cs
@@ -10,7 +10,7 @@ namespace MetaBrainz.MusicBrainz.CoverArt;
 [PublicAPI]
 public sealed class CoverArtImage : IDisposable {
 
-  internal CoverArtImage(string id, CoverArtImageSize size, string type, Stream data) {
+  internal CoverArtImage(string id, CoverArtImageSize size, string? type, Stream data) {
     this.Id = id;
     this.Size = size;
     this.ContentType = type;
@@ -23,8 +23,8 @@ public sealed class CoverArtImage : IDisposable {
   /// <summary>The image's size.</summary>
   public readonly CoverArtImageSize Size;
 
-  /// <summary>The content type for the image.</summary>
-  public readonly string ContentType;
+  /// <summary>The content type for the image, if known.</summary>
+  public readonly string? ContentType;
 
   /// <summary>The image's raw data.</summary>
   public readonly Stream Data;

--- a/MetaBrainz.MusicBrainz.CoverArt/MetaBrainz.MusicBrainz.CoverArt.csproj
+++ b/MetaBrainz.MusicBrainz.CoverArt/MetaBrainz.MusicBrainz.CoverArt.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="JetBrains.Annotations" IncludeAssets="compile" PrivateAssets="all" />
     <PackageReference Include="MetaBrainz.Common.Json" />
     <PackageReference Include="System.Drawing.Common" />
+    <PackageReference Include="System.Net.Http" />
     <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 


### PR DESCRIPTION
This adds a dependency on System.Net.Http 4.3.4.

The internal code is now async only; the non-Async public API merely waits for the result of the asynchronous task.

API Changes:
- `CoverArt` is now `IDisposable`.
- `CoverArt.[Default]WebSite` is now called `CoverArt.[Default]Server`.
- New static properties `CoverArt.DefaultContactInfo`, `CoverArt.DefaultProductInto`, `CoverArt.DefaultUrlScheme`.
- New properties `CoverArt.BaseUri`, `CoverArt.ContactInfo`, `CoverArt.ProductInto`, `CoverArt.UrlScheme`.
- Adjusted the `CoverArt` constructors to provide overloads for setting contact and/or product info.
  - Whichever is not passed needs to have been previously set via the `DefaultXxx` static properties.
- The `ContentType` property of `CoverArtImage` is now nullable.

This also updates System.Drawing.Common to version 6.0.0, marking `CoverArtImage.Decode` as supported on Windows only to avoid the `CA1416` warning.