### PR TITLE
Use `MetaBrainz.Common`

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,6 +4,7 @@
   <!-- Package Versions -->
   <ItemGroup>
     <PackageVersion Include="JetBrains.Annotations" Version="2021.3.0" />
+    <PackageVersion Include="MetaBrainz.Common" Version="1.0.0" />
     <PackageVersion Include="MetaBrainz.Common.Json" Version="5.1.0" />
     <PackageVersion Include="System.Drawing.Common" Version="6.0.0" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />

--- a/MetaBrainz.MusicBrainz.CoverArt/MetaBrainz.MusicBrainz.CoverArt.csproj
+++ b/MetaBrainz.MusicBrainz.CoverArt/MetaBrainz.MusicBrainz.CoverArt.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" IncludeAssets="compile" PrivateAssets="all" />
+    <PackageReference Include="MetaBrainz.Common" />
     <PackageReference Include="MetaBrainz.Common.Json" />
     <PackageReference Include="System.Drawing.Common" />
     <PackageReference Include="System.Net.Http" />


### PR DESCRIPTION
This drops a few utility methods (`FormatMultiLine()`, `ResultOf()`) in favour of equivalent methods provided by `MetaBrainz.Common` (in `TextUtils` and `AsyncUtils`, respectively).

It also replaces most of `FetchReleaseAsync()` with a call to `JsonUtils.GetJsonContentAsync()`.