### PR TITLE
Update the build SDK to version 3.1.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,13 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    labels:
+      - "dependencies"
+      - "nuget"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "dependencies"
+      - "gh-actions"

--- a/.github/github-labels.yml
+++ b/.github/github-labels.yml
@@ -36,6 +36,14 @@
   color: '008672'
   description: "Changes related to unit tests"
 
+# Additional Labels Used by Dependabot
+- name: gh-actions
+  color: '1d0128'
+  description: "Version updates for GitHub actions"
+- name: nuget
+  color: '1d0128'
+  description: "Version updates for NuGet packages"
+
 # Additional Labels for Release Drafter Version Resolution
 - name: bump-major-version
   color: 'cf996b'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,52 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - 'main'
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+  pull_request:
+    branches:
+      - 'main'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      dotnet-version: 8.0.x
+    strategy:
+      matrix:
+        configuration: ['Debug', 'Release']
+
+    steps:
+    - name: Check out the project
+      uses: actions/checkout@v4
+    - name: Set up .NET ${{env.dotnet-version}}
+      uses: actions/setup-dotnet@v4
+      id: setup
+      with:
+        dotnet-version: ${{env.dotnet-version}}
+      env:
+        NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+    - name: Create global.json to force use of .NET SDK ${{steps.setup.outputs.dotnet-version}}
+      run: echo '{"sdk":{"version":"${{steps.setup.outputs.dotnet-version}}"}}' > ./global.json
+    - name: Run build script (${{matrix.configuration}})
+      run: pwsh ./build-package.ps1 -ContinuousIntegration -WithBinLog -Configuration ${{matrix.configuration}}
+    - name: "Artifact: MSBuild Logs"
+      uses: actions/upload-artifact@v3
+      if: failure()
+      with:
+        name: MSBuild Logs (${{matrix.configuration}})
+        path: msbuild.*.binlog
+    - name: "Artifact: NuGet Packages"
+      uses: actions/upload-artifact@v3
+      with:
+        name: NuGet Packages (${{matrix.configuration}})
+        path: "output/package/${{matrix.configuration}}/*.*nupkg"
+    - name: Publish (NuGet - GitHub Packages)
+      if: matrix.configuration == 'Release' && startsWith(github.ref, 'refs/tags/v')
+      run: "dotnet nuget push output/package/${{matrix.configuration}}/*.nupkg -s https://nuget.pkg.github.com/zastai/index.json -k ${{secrets.GITHUB_TOKEN}}"
+    - name: Publish (NuGet - nuget.org)
+      if: matrix.configuration == 'Release' && startsWith(github.ref, 'refs/tags/v')
+      run: "dotnet nuget push output/package/${{matrix.configuration}}/*.nupkg -s https://api.nuget.org/v3/index.json -k ${{secrets.NUGET_API_KEY}}"

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -10,6 +10,6 @@ jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v5.15.0
+      - uses: release-drafter/release-drafter@v5.25.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-labels.yml
+++ b/.github/workflows/update-labels.yml
@@ -7,12 +7,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run Labeler
         if: success()
-        uses: crazy-max/ghaction-github-labeler@v3
+        uses: crazy-max/ghaction-github-labeler@v5
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           yaml-file: .github/github-labels.yml

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,12 +3,11 @@
 
   <!-- Package Versions -->
   <ItemGroup>
-    <PackageVersion Include="JetBrains.Annotations" Version="2023.2.0" />
+    <PackageVersion Include="JetBrains.Annotations" Version="2023.3.0" />
     <PackageVersion Include="MetaBrainz.Common" Version="1.0.0" />
     <PackageVersion Include="MetaBrainz.Common.Json" Version="5.1.0" />
-    <PackageVersion Include="System.Drawing.Common" Version="6.0.0" />
-    <PackageVersion Include="System.Net.Http" Version="4.3.4" />
-    <PackageVersion Include="System.Text.Json" Version="6.0.0" />
+    <PackageVersion Include="System.Drawing.Common" Version="6.0.0" Condition=" '$(TargetFramework)' == 'net6.0' " />
+    <PackageVersion Include="System.Drawing.Common" Version="8.0.0" Condition=" '$(TargetFramework)' == 'net8.0' " />
   </ItemGroup>
 
 </Project>

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # MIT License
 
-Copyright (c) 2021 Tim Van Holder
+Copyright (c) 2016-2023 Tim Van Holder
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/MetaBrainz.MusicBrainz.CoverArt.sln
+++ b/MetaBrainz.MusicBrainz.CoverArt.sln
@@ -8,10 +8,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Support Files", "Support Fi
 		.editorconfig = .editorconfig
 		.gitattributes = .gitattributes
 		.gitignore = .gitignore
-		appveyor.yml = appveyor.yml
 		build-package.ps1 = build-package.ps1
 		Directory.Packages.props = Directory.Packages.props
-		global.json = global.json
 		LICENSE.md = LICENSE.md
 		package-icon.png = package-icon.png
 		README.md = README.md
@@ -26,6 +24,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "GitHub", "GitHub", "{5E6BB8
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Actions", "Actions", "{47A089B9-B7FA-435A-8771-9AD4BE1D1D5C}"
 	ProjectSection(SolutionItems) = preProject
+		.github\workflows\build.yml = .github\workflows\build.yml
 		.github\workflows\release-drafter.yml = .github\workflows\release-drafter.yml
 		.github\workflows\update-labels.yml = .github\workflows\update-labels.yml
 	EndProjectSection

--- a/MetaBrainz.MusicBrainz.CoverArt/CoverArtImage.cs
+++ b/MetaBrainz.MusicBrainz.CoverArt/CoverArtImage.cs
@@ -37,9 +37,7 @@ public sealed class CoverArtImage : IDisposable {
   /// When the image data is not valid (or not supported by the <see cref="System.Drawing.Image"/> class).
   /// </exception>
   /// <exception cref="PlatformNotSupportedException">When not running on Windows.</exception>
-#if NET
   [SupportedOSPlatform("windows")]
-#endif
   public Image Decode(bool useEmbeddedColorManagement = false, bool validateImageData = false)
     => Image.FromStream(this.Data, useEmbeddedColorManagement, validateImageData);
 

--- a/MetaBrainz.MusicBrainz.CoverArt/Json/Readers/ImageReader.cs
+++ b/MetaBrainz.MusicBrainz.CoverArt/Json/Readers/ImageReader.cs
@@ -12,7 +12,7 @@ namespace MetaBrainz.MusicBrainz.CoverArt.Json.Readers;
 
 internal sealed class ImageReader : ObjectReader<Image> {
 
-  public static readonly ImageReader Instance = new ImageReader();
+  public static readonly ImageReader Instance = new();
 
   protected override Image ReadObjectContents(ref Utf8JsonReader reader, JsonSerializerOptions options) {
     var approved = false;

--- a/MetaBrainz.MusicBrainz.CoverArt/Json/Readers/ReleaseReader.cs
+++ b/MetaBrainz.MusicBrainz.CoverArt/Json/Readers/ReleaseReader.cs
@@ -11,7 +11,7 @@ namespace MetaBrainz.MusicBrainz.CoverArt.Json.Readers;
 
 internal sealed class ReleaseReader : ObjectReader<Release> {
 
-  public static readonly ReleaseReader Instance = new ReleaseReader();
+  public static readonly ReleaseReader Instance = new();
 
   protected override Release ReadObjectContents(ref Utf8JsonReader reader, JsonSerializerOptions options) {
     IReadOnlyList<IImage>? images = null;

--- a/MetaBrainz.MusicBrainz.CoverArt/Json/Readers/ThumbnailsReader.cs
+++ b/MetaBrainz.MusicBrainz.CoverArt/Json/Readers/ThumbnailsReader.cs
@@ -10,7 +10,7 @@ namespace MetaBrainz.MusicBrainz.CoverArt.Json.Readers;
 
 internal sealed class ThumbnailsReader : ObjectReader<Thumbnails> {
 
-  public static readonly ThumbnailsReader Instance = new ThumbnailsReader();
+  public static readonly ThumbnailsReader Instance = new();
 
   protected override Thumbnails ReadObjectContents(ref Utf8JsonReader reader, JsonSerializerOptions options) {
     Uri? small = null;

--- a/MetaBrainz.MusicBrainz.CoverArt/MetaBrainz.MusicBrainz.CoverArt.csproj
+++ b/MetaBrainz.MusicBrainz.CoverArt/MetaBrainz.MusicBrainz.CoverArt.csproj
@@ -1,16 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="MetaBrainz.Build.Sdk">
+<Project>
+
+  <Sdk Name="MetaBrainz.Build.Sdk" Version="3.1.0" />
 
   <PropertyGroup>
+    <Authors>Zastai</Authors>
     <Title>CoverArt Archive Web Service Client Library</Title>
     <Description>
       This package provides classes for accessing the CoverArt Archive (CAA), enabling the retrieval of cover art for music releases
       based on their MusicBrainz ID.
     </Description>
+    <PackageCopyrightOwners>Tim Van Holder</PackageCopyrightOwners>
     <PackageCopyrightYears>2016-2023</PackageCopyrightYears>
     <PackageRepositoryName>MetaBrainz.MusicBrainz.CoverArt</PackageRepositoryName>
     <PackageTags>MusicBrainz album cover art archive CAA libcoverart</PackageTags>
-    <Version>5.1.1-pre</Version>
+    <Version>6.0.0-pre</Version>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <AssemblyIsComVisible>false</AssemblyIsComVisible>
   </PropertyGroup>
 
   <ItemGroup>
@@ -18,8 +26,6 @@
     <PackageReference Include="MetaBrainz.Common" />
     <PackageReference Include="MetaBrainz.Common.Json" />
     <PackageReference Include="System.Drawing.Common" />
-    <PackageReference Include="System.Net.Http" />
-    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 
 </Project>

--- a/MetaBrainz.MusicBrainz.CoverArt/Objects/Image.cs
+++ b/MetaBrainz.MusicBrainz.CoverArt/Objects/Image.cs
@@ -15,24 +15,24 @@ internal sealed class Image : JsonBasedObject, IImage {
     this.Types = types;
   }
 
-  public bool Approved { get; set; }
+  public bool Approved { get; init; }
 
-  public bool Back { get; set; }
+  public bool Back { get; init; }
 
-  public string? Comment { get; set; }
+  public string? Comment { get; init; }
 
   public int Edit { get; }
 
-  public bool Front { get; set; }
+  public bool Front { get; init; }
 
   public string Id { get; }
 
-  public Uri? Location { get; set; }
+  public Uri? Location { get; init; }
 
   public IThumbnails Thumbnails { get; }
 
   public CoverArtType Types { get; }
 
-  public IReadOnlyList<string>? UnknownTypes { get; set; }
+  public IReadOnlyList<string>? UnknownTypes { get; init; }
 
 }

--- a/MetaBrainz.MusicBrainz.CoverArt/Objects/Thumbnails.cs
+++ b/MetaBrainz.MusicBrainz.CoverArt/Objects/Thumbnails.cs
@@ -7,14 +7,14 @@ namespace MetaBrainz.MusicBrainz.CoverArt.Objects;
 
 internal sealed class Thumbnails : JsonBasedObject, IThumbnails {
 
-  public Uri? Small { get; set; }
+  public Uri? Small { get; init; }
 
-  public Uri? Large { get; set; }
+  public Uri? Large { get; init; }
 
-  public Uri? Size250 { get; set; }
+  public Uri? Size250 { get; init; }
 
-  public Uri? Size500 { get; set; }
+  public Uri? Size500 { get; init; }
 
-  public Uri? Size1200 { get; set; }
+  public Uri? Size1200 { get; init; }
 
 }

--- a/MetaBrainz.MusicBrainz.CoverArt/Properties/AssemblyInfo.cs
+++ b/MetaBrainz.MusicBrainz.CoverArt/Properties/AssemblyInfo.cs
@@ -1,3 +1,0 @@
-using System.Runtime.InteropServices;
-
-[assembly: ComVisible(false)]

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ This is a .NET implementation of the libcoverart library (wrapping the
 [CoverArtArchive API][api-reference]).
 An attempt has been made to keep the same basic class hierarchy.
 
-[CI-S]: https://img.shields.io/appveyor/build/zastai/metabrainz-musicbrainz-coverart
-[CI-L]: https://ci.appveyor.com/project/Zastai/metabrainz-musicbrainz-coverart
+[CI-S]: https://github.com/Zastai/MetaBrainz.MusicBrainz.CoverArt/actions/workflows/build.yml/badge.svg
+[CI-L]: https://github.com/Zastai/MetaBrainz.MusicBrainz.CoverArt/actions/workflows/build.yml
 [NuGet-S]: https://img.shields.io/nuget/v/MetaBrainz.MusicBrainz.CoverArt
 [NuGet-L]: https://www.nuget.org/packages/MetaBrainz.MusicBrainz.CoverArt
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,0 @@
-version: 'Build #{build}'
-image: Visual Studio 2022
-build_script:
-  - ps: .\build-package.ps1 -Configuration Debug
-after_build:
-  - ps: Get-ChildItem output/package/*/*.nupkg | % { appveyor PushArtifact $_ }

--- a/build-package.ps1
+++ b/build-package.ps1
@@ -3,6 +3,7 @@
 [CmdletBinding()]
 param (
   [string] $Configuration = 'Release',
+  [switch] $ContinuousIntegration = $false,
   [switch] $WithBinLog = $false
 )
 
@@ -41,7 +42,15 @@ if ($LASTEXITCODE -ne 0) {
 }
 
 Write-Host "Building the solution (Configuration: $Configuration)..."
-dotnet build $opts --no-restore "-c:$Configuration" '-p:ContinuousIntegrationBuild=true' '-p:Deterministic=true'
+$props = @()
+if ($ContinuousIntegration) {
+  $props += '-p:ContinuousIntegrationBuild=true'
+  $props += '-p:Deterministic=true'
+}
+if ($Configuration -eq 'Debug') {
+  $props += '-p:DebugMessageImportance=high'
+}
+dotnet build $opts --no-restore "-c:$Configuration" $props
 Complete-BuildStep 'build'
 if ($LASTEXITCODE -ne 0) {
   Write-Error "SOLUTION BUILD FAILED"

--- a/global.json
+++ b/global.json
@@ -1,5 +1,0 @@
-{
-  "msbuild-sdks": {
-    "MetaBrainz.Build.Sdk" : "2.1.2"
-  }
-}

--- a/public-api/MetaBrainz.MusicBrainz.CoverArt.net6.0.cs.md
+++ b/public-api/MetaBrainz.MusicBrainz.CoverArt.net6.0.cs.md
@@ -1,0 +1,320 @@
+﻿# API Reference: MetaBrainz.MusicBrainz.CoverArt
+
+## Assembly Attributes
+
+```cs
+[assembly: System.Runtime.InteropServices.ComVisibleAttribute(false)]
+[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETCoreApp,Version=v6.0", FrameworkDisplayName = ".NET 6.0")]
+```
+
+## Namespace: MetaBrainz.MusicBrainz.CoverArt
+
+### Type: CoverArt
+
+```cs
+public class CoverArt : System.IDisposable {
+
+  public const int MaxImageSize = 536870912;
+
+  public const string UserAgentUrl = "https://github.com/Zastai/MetaBrainz.MusicBrainz.CoverArt";
+
+  System.Uri BaseUri {
+    public get;
+  }
+
+  System.Uri ContactInfo {
+    public get;
+  }
+
+  System.Uri? DefaultContactInfo {
+    public static get;
+    public static set;
+  }
+
+  int DefaultPort {
+    public static get;
+    public static set;
+  }
+
+  System.Net.Http.Headers.ProductHeaderValue? DefaultProductInfo {
+    public static get;
+    public static set;
+  }
+
+  string DefaultServer {
+    public static get;
+    public static set;
+  }
+
+  string DefaultUrlScheme {
+    public static get;
+    public static set;
+  }
+
+  string DefaultUserAgent {
+    public static get;
+    public static set;
+  }
+
+  int Port {
+    public get;
+    public set;
+  }
+
+  System.Net.Http.Headers.ProductHeaderValue ProductInfo {
+    public get;
+  }
+
+  string Server {
+    public get;
+    public set;
+  }
+
+  string UrlScheme {
+    public get;
+    public set;
+  }
+
+  public CoverArt();
+
+  public CoverArt(System.Net.Http.Headers.ProductHeaderValue product);
+
+  public CoverArt(System.Net.Http.Headers.ProductHeaderValue product, System.Uri contact);
+
+  public CoverArt(System.Net.Http.Headers.ProductHeaderValue product, string contact);
+
+  public CoverArt(System.Uri contact);
+
+  public CoverArt(string contact);
+
+  public CoverArt(string application, System.Version version);
+
+  public CoverArt(string application, System.Version version, System.Uri contact);
+
+  public CoverArt(string application, System.Version version, string contact);
+
+  public CoverArt(string application, string version);
+
+  public CoverArt(string application, string version, System.Uri contact);
+
+  public CoverArt(string application, string version, string contact);
+
+  public void Close();
+
+  public sealed override void Dispose();
+
+  public CoverArtImage FetchBack(System.Guid mbid, CoverArtImageSize size = CoverArtImageSize.Original);
+
+  public System.Threading.Tasks.Task<CoverArtImage> FetchBackAsync(System.Guid mbid, CoverArtImageSize size = CoverArtImageSize.Original, System.Threading.CancellationToken cancellationToken = default);
+
+  public CoverArtImage FetchFront(System.Guid mbid, CoverArtImageSize size = CoverArtImageSize.Original);
+
+  public System.Threading.Tasks.Task<CoverArtImage> FetchFrontAsync(System.Guid mbid, CoverArtImageSize size = CoverArtImageSize.Original, System.Threading.CancellationToken cancellationToken = default);
+
+  public CoverArtImage FetchGroupFront(System.Guid mbid, CoverArtImageSize size = CoverArtImageSize.Original);
+
+  public System.Threading.Tasks.Task<CoverArtImage> FetchGroupFrontAsync(System.Guid mbid, CoverArtImageSize size = CoverArtImageSize.Original, System.Threading.CancellationToken cancellationToken = default);
+
+  public MetaBrainz.MusicBrainz.CoverArt.Interfaces.IRelease FetchGroupRelease(System.Guid mbid);
+
+  public System.Threading.Tasks.Task<MetaBrainz.MusicBrainz.CoverArt.Interfaces.IRelease> FetchGroupReleaseAsync(System.Guid mbid, System.Threading.CancellationToken cancellationToken = default);
+
+  public MetaBrainz.MusicBrainz.CoverArt.Interfaces.IRelease? FetchGroupReleaseIfAvailable(System.Guid mbid);
+
+  public System.Threading.Tasks.Task<MetaBrainz.MusicBrainz.CoverArt.Interfaces.IRelease?> FetchGroupReleaseIfAvailableAsync(System.Guid mbid, System.Threading.CancellationToken cancellationToken = default);
+
+  public CoverArtImage FetchImage(System.Guid mbid, string id, CoverArtImageSize size = CoverArtImageSize.Original);
+
+  public System.Threading.Tasks.Task<CoverArtImage> FetchImageAsync(System.Guid mbid, string id, CoverArtImageSize size = CoverArtImageSize.Original, System.Threading.CancellationToken cancellationToken = default);
+
+  public MetaBrainz.MusicBrainz.CoverArt.Interfaces.IRelease FetchRelease(System.Guid mbid);
+
+  public System.Threading.Tasks.Task<MetaBrainz.MusicBrainz.CoverArt.Interfaces.IRelease> FetchReleaseAsync(System.Guid mbid, System.Threading.CancellationToken cancellationToken = default);
+
+  public MetaBrainz.MusicBrainz.CoverArt.Interfaces.IRelease? FetchReleaseIfAvailable(System.Guid mbid);
+
+  public System.Threading.Tasks.Task<MetaBrainz.MusicBrainz.CoverArt.Interfaces.IRelease?> FetchReleaseIfAvailableAsync(System.Guid mbid, System.Threading.CancellationToken cancellationToken = default);
+
+  protected override void Finalize();
+
+}
+```
+
+### Type: CoverArtImage
+
+```cs
+public sealed class CoverArtImage : System.IDisposable {
+
+  public readonly string? ContentType;
+
+  public readonly System.IO.Stream Data;
+
+  public readonly string Id;
+
+  public readonly CoverArtImageSize Size;
+
+  [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
+  public System.Drawing.Image Decode(bool useEmbeddedColorManagement = false, bool validateImageData = false);
+
+  public sealed override void Dispose();
+
+  protected override void Finalize();
+
+}
+```
+
+### Type: CoverArtImageSize
+
+```cs
+public enum CoverArtImageSize {
+
+  HugeThumbnail = 1200,
+  LargeThumbnail = 500,
+  Original = 0,
+  SmallThumbnail = 250,
+
+}
+```
+
+### Type: CoverArtType
+
+```cs
+[System.FlagsAttribute]
+public enum CoverArtType : long {
+
+  Back = 2L,
+  Booklet = 4L,
+  Front = 1L,
+  Liner = 256L,
+  Medium = 8L,
+  None = 0L,
+  Obi = 32L,
+  Other = -9223372036854775808L,
+  Poster = 1024L,
+  RawUnedited = 4096L,
+  Spine = 64L,
+  Sticker = 512L,
+  Track = 128L,
+  Tray = 16L,
+  Unknown = 4611686018427387904L,
+  Watermark = 2048L,
+
+}
+```
+
+### Type: HttpError
+
+```cs
+[System.SerializableAttribute]
+public class HttpError : System.Exception {
+
+  string? Reason {
+    public get;
+  }
+
+  System.Net.HttpStatusCode Status {
+    public get;
+  }
+
+  public HttpError(System.Net.Http.HttpResponseMessage response);
+
+  public HttpError(System.Net.HttpStatusCode status, string? reason);
+
+  public override string ToString();
+
+}
+```
+
+## Namespace: MetaBrainz.MusicBrainz.CoverArt.Interfaces
+
+### Type: IImage
+
+```cs
+public interface IImage : MetaBrainz.Common.Json.IJsonBasedObject {
+
+  bool Approved {
+    public abstract get;
+  }
+
+  bool Back {
+    public abstract get;
+  }
+
+  string? Comment {
+    public abstract get;
+  }
+
+  int Edit {
+    public abstract get;
+  }
+
+  bool Front {
+    public abstract get;
+  }
+
+  string Id {
+    public abstract get;
+  }
+
+  System.Uri? Location {
+    public abstract get;
+  }
+
+  IThumbnails Thumbnails {
+    public abstract get;
+  }
+
+  MetaBrainz.MusicBrainz.CoverArt.CoverArtType Types {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<string>? UnknownTypes {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: IRelease
+
+```cs
+public interface IRelease : MetaBrainz.Common.Json.IJsonBasedObject {
+
+  System.Collections.Generic.IReadOnlyList<IImage> Images {
+    public abstract get;
+  }
+
+  System.Uri Location {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: IThumbnails
+
+```cs
+public interface IThumbnails : MetaBrainz.Common.Json.IJsonBasedObject {
+
+  System.Uri? Large {
+    public abstract get;
+  }
+
+  System.Uri? Size1200 {
+    public abstract get;
+  }
+
+  System.Uri? Size250 {
+    public abstract get;
+  }
+
+  System.Uri? Size500 {
+    public abstract get;
+  }
+
+  System.Uri? Small {
+    public abstract get;
+  }
+
+}
+```

--- a/public-api/MetaBrainz.MusicBrainz.CoverArt.net8.0.cs.md
+++ b/public-api/MetaBrainz.MusicBrainz.CoverArt.net8.0.cs.md
@@ -1,0 +1,320 @@
+﻿# API Reference: MetaBrainz.MusicBrainz.CoverArt
+
+## Assembly Attributes
+
+```cs
+[assembly: System.Runtime.InteropServices.ComVisibleAttribute(false)]
+[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETCoreApp,Version=v8.0", FrameworkDisplayName = ".NET 8.0")]
+```
+
+## Namespace: MetaBrainz.MusicBrainz.CoverArt
+
+### Type: CoverArt
+
+```cs
+public class CoverArt : System.IDisposable {
+
+  public const int MaxImageSize = 536870912;
+
+  public const string UserAgentUrl = "https://github.com/Zastai/MetaBrainz.MusicBrainz.CoverArt";
+
+  System.Uri BaseUri {
+    public get;
+  }
+
+  System.Uri ContactInfo {
+    public get;
+  }
+
+  System.Uri? DefaultContactInfo {
+    public static get;
+    public static set;
+  }
+
+  int DefaultPort {
+    public static get;
+    public static set;
+  }
+
+  System.Net.Http.Headers.ProductHeaderValue? DefaultProductInfo {
+    public static get;
+    public static set;
+  }
+
+  string DefaultServer {
+    public static get;
+    public static set;
+  }
+
+  string DefaultUrlScheme {
+    public static get;
+    public static set;
+  }
+
+  string DefaultUserAgent {
+    public static get;
+    public static set;
+  }
+
+  int Port {
+    public get;
+    public set;
+  }
+
+  System.Net.Http.Headers.ProductHeaderValue ProductInfo {
+    public get;
+  }
+
+  string Server {
+    public get;
+    public set;
+  }
+
+  string UrlScheme {
+    public get;
+    public set;
+  }
+
+  public CoverArt();
+
+  public CoverArt(System.Net.Http.Headers.ProductHeaderValue product);
+
+  public CoverArt(System.Net.Http.Headers.ProductHeaderValue product, System.Uri contact);
+
+  public CoverArt(System.Net.Http.Headers.ProductHeaderValue product, string contact);
+
+  public CoverArt(System.Uri contact);
+
+  public CoverArt(string contact);
+
+  public CoverArt(string application, System.Version version);
+
+  public CoverArt(string application, System.Version version, System.Uri contact);
+
+  public CoverArt(string application, System.Version version, string contact);
+
+  public CoverArt(string application, string version);
+
+  public CoverArt(string application, string version, System.Uri contact);
+
+  public CoverArt(string application, string version, string contact);
+
+  public void Close();
+
+  public sealed override void Dispose();
+
+  public CoverArtImage FetchBack(System.Guid mbid, CoverArtImageSize size = CoverArtImageSize.Original);
+
+  public System.Threading.Tasks.Task<CoverArtImage> FetchBackAsync(System.Guid mbid, CoverArtImageSize size = CoverArtImageSize.Original, System.Threading.CancellationToken cancellationToken = default);
+
+  public CoverArtImage FetchFront(System.Guid mbid, CoverArtImageSize size = CoverArtImageSize.Original);
+
+  public System.Threading.Tasks.Task<CoverArtImage> FetchFrontAsync(System.Guid mbid, CoverArtImageSize size = CoverArtImageSize.Original, System.Threading.CancellationToken cancellationToken = default);
+
+  public CoverArtImage FetchGroupFront(System.Guid mbid, CoverArtImageSize size = CoverArtImageSize.Original);
+
+  public System.Threading.Tasks.Task<CoverArtImage> FetchGroupFrontAsync(System.Guid mbid, CoverArtImageSize size = CoverArtImageSize.Original, System.Threading.CancellationToken cancellationToken = default);
+
+  public MetaBrainz.MusicBrainz.CoverArt.Interfaces.IRelease FetchGroupRelease(System.Guid mbid);
+
+  public System.Threading.Tasks.Task<MetaBrainz.MusicBrainz.CoverArt.Interfaces.IRelease> FetchGroupReleaseAsync(System.Guid mbid, System.Threading.CancellationToken cancellationToken = default);
+
+  public MetaBrainz.MusicBrainz.CoverArt.Interfaces.IRelease? FetchGroupReleaseIfAvailable(System.Guid mbid);
+
+  public System.Threading.Tasks.Task<MetaBrainz.MusicBrainz.CoverArt.Interfaces.IRelease?> FetchGroupReleaseIfAvailableAsync(System.Guid mbid, System.Threading.CancellationToken cancellationToken = default);
+
+  public CoverArtImage FetchImage(System.Guid mbid, string id, CoverArtImageSize size = CoverArtImageSize.Original);
+
+  public System.Threading.Tasks.Task<CoverArtImage> FetchImageAsync(System.Guid mbid, string id, CoverArtImageSize size = CoverArtImageSize.Original, System.Threading.CancellationToken cancellationToken = default);
+
+  public MetaBrainz.MusicBrainz.CoverArt.Interfaces.IRelease FetchRelease(System.Guid mbid);
+
+  public System.Threading.Tasks.Task<MetaBrainz.MusicBrainz.CoverArt.Interfaces.IRelease> FetchReleaseAsync(System.Guid mbid, System.Threading.CancellationToken cancellationToken = default);
+
+  public MetaBrainz.MusicBrainz.CoverArt.Interfaces.IRelease? FetchReleaseIfAvailable(System.Guid mbid);
+
+  public System.Threading.Tasks.Task<MetaBrainz.MusicBrainz.CoverArt.Interfaces.IRelease?> FetchReleaseIfAvailableAsync(System.Guid mbid, System.Threading.CancellationToken cancellationToken = default);
+
+  protected override void Finalize();
+
+}
+```
+
+### Type: CoverArtImage
+
+```cs
+public sealed class CoverArtImage : System.IDisposable {
+
+  public readonly string? ContentType;
+
+  public readonly System.IO.Stream Data;
+
+  public readonly string Id;
+
+  public readonly CoverArtImageSize Size;
+
+  [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
+  public System.Drawing.Image Decode(bool useEmbeddedColorManagement = false, bool validateImageData = false);
+
+  public sealed override void Dispose();
+
+  protected override void Finalize();
+
+}
+```
+
+### Type: CoverArtImageSize
+
+```cs
+public enum CoverArtImageSize {
+
+  HugeThumbnail = 1200,
+  LargeThumbnail = 500,
+  Original = 0,
+  SmallThumbnail = 250,
+
+}
+```
+
+### Type: CoverArtType
+
+```cs
+[System.FlagsAttribute]
+public enum CoverArtType : long {
+
+  Back = 2L,
+  Booklet = 4L,
+  Front = 1L,
+  Liner = 256L,
+  Medium = 8L,
+  None = 0L,
+  Obi = 32L,
+  Other = -9223372036854775808L,
+  Poster = 1024L,
+  RawUnedited = 4096L,
+  Spine = 64L,
+  Sticker = 512L,
+  Track = 128L,
+  Tray = 16L,
+  Unknown = 4611686018427387904L,
+  Watermark = 2048L,
+
+}
+```
+
+### Type: HttpError
+
+```cs
+[System.SerializableAttribute]
+public class HttpError : System.Exception {
+
+  string? Reason {
+    public get;
+  }
+
+  System.Net.HttpStatusCode Status {
+    public get;
+  }
+
+  public HttpError(System.Net.Http.HttpResponseMessage response);
+
+  public HttpError(System.Net.HttpStatusCode status, string? reason);
+
+  public override string ToString();
+
+}
+```
+
+## Namespace: MetaBrainz.MusicBrainz.CoverArt.Interfaces
+
+### Type: IImage
+
+```cs
+public interface IImage : MetaBrainz.Common.Json.IJsonBasedObject {
+
+  bool Approved {
+    public abstract get;
+  }
+
+  bool Back {
+    public abstract get;
+  }
+
+  string? Comment {
+    public abstract get;
+  }
+
+  int Edit {
+    public abstract get;
+  }
+
+  bool Front {
+    public abstract get;
+  }
+
+  string Id {
+    public abstract get;
+  }
+
+  System.Uri? Location {
+    public abstract get;
+  }
+
+  IThumbnails Thumbnails {
+    public abstract get;
+  }
+
+  MetaBrainz.MusicBrainz.CoverArt.CoverArtType Types {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<string>? UnknownTypes {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: IRelease
+
+```cs
+public interface IRelease : MetaBrainz.Common.Json.IJsonBasedObject {
+
+  System.Collections.Generic.IReadOnlyList<IImage> Images {
+    public abstract get;
+  }
+
+  System.Uri Location {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: IThumbnails
+
+```cs
+public interface IThumbnails : MetaBrainz.Common.Json.IJsonBasedObject {
+
+  System.Uri? Large {
+    public abstract get;
+  }
+
+  System.Uri? Size1200 {
+    public abstract get;
+  }
+
+  System.Uri? Size250 {
+    public abstract get;
+  }
+
+  System.Uri? Size500 {
+    public abstract get;
+  }
+
+  System.Uri? Small {
+    public abstract get;
+  }
+
+}
+```


### PR DESCRIPTION
- update GitHub Actions
- drop AppVeyor builds
  - instead, use GitHub Actions for CI
- enable Dependabot for GitHub Actions and configure labels for it
- set `AssemblyIsComVisible` to `false` in the project file
  - allows dropping the `AssemblyInfo.cs` file
- align copyright years between license file and project
- target `net6.0` and `net8.0` only
  - allows dropping some compatibility code
  - switch the object properties over to init-only
  - reference the corresponding `System.Drawing.Common` version
  - bump version to 6.0.0-pre

This also bumps `JetBrains.Annotations` to version 2023.3.0.