### PR TITLE
Update dependencies & ad more error details

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
   <!-- Package Versions -->
   <ItemGroup>
     <PackageVersion Include="JetBrains.Annotations" Version="2023.3.0" />
-    <PackageVersion Include="MetaBrainz.Common" Version="2.1.0" />
+    <PackageVersion Include="MetaBrainz.Common" Version="3.0.0" />
     <PackageVersion Include="MetaBrainz.Common.Json" Version="6.0.0" />
     <PackageVersion Include="System.Drawing.Common" Version="6.0.0" Condition=" '$(TargetFramework)' == 'net6.0' " />
     <PackageVersion Include="System.Drawing.Common" Version="8.0.0" Condition=" '$(TargetFramework)' == 'net8.0' " />

--- a/MetaBrainz.MusicBrainz.CoverArt/MetaBrainz.MusicBrainz.CoverArt.csproj
+++ b/MetaBrainz.MusicBrainz.CoverArt/MetaBrainz.MusicBrainz.CoverArt.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
 
-  <Sdk Name="MetaBrainz.Build.Sdk" Version="3.1.1" />
+  <Sdk Name="MetaBrainz.Build.Sdk" Version="3.1.2" />
 
   <PropertyGroup>
     <Authors>Zastai</Authors>


### PR DESCRIPTION
This updates `MetaBrainz.Build.Sdk` to version 3.1.2 and `MetaBrainz.Common` to version 3.0.0.

When the web services reports an error that contains HTML ending with

```html
<title>error code and text</title>
<h1>error text</h1>
<p>description of the error</p>
```

then an `HttpError` will now be thrown using the code, text and message from those contents (with the original "plain" HTTP error as inner exception).