### PR TITLE
Drop non-async versions of methods

### DIFF
--- a/MetaBrainz.MusicBrainz.CoverArt/CoverArt.EndPoints.cs
+++ b/MetaBrainz.MusicBrainz.CoverArt/CoverArt.EndPoints.cs
@@ -18,31 +18,6 @@ public sealed partial class CoverArt {
   /// The requested image size; <see cref="CoverArtImageSize.Original"/> can be any content type, but the thumbnails are always
   /// JPEG.
   /// </param>
-  /// <returns>The requested image data.</returns>
-  /// <exception cref="HttpError">
-  /// When the request succeeded but reported an HTTP error status; the most common cases will be:
-  /// <ul><li>
-  ///   404 (<see cref="HttpStatusCode.NotFound"/>) when the release does not exist (or has no "back" image set);
-  /// </li><li>
-  ///   503 (<see cref="HttpStatusCode.ServiceUnavailable"/>) when the server is unavailable, or rate limiting is in effect.
-  /// </li></ul>
-  /// </exception>
-  /// <exception cref="HttpRequestException">
-  /// When the request failed due to an underlying issue such as network connectivity, DNS failure, server certificate validation or
-  /// timeout.
-  /// </exception>
-  /// <exception cref="TaskCanceledException">
-  /// When the request failed due to timeout (.NET Core and .NET 5 and later only).
-  /// </exception>
-  public CoverArtImage FetchBack(Guid mbid, CoverArtImageSize size = CoverArtImageSize.Original)
-    => AsyncUtils.ResultOf(this.FetchBackAsync(mbid, size));
-
-  /// <summary>Fetch the main "back" image for the specified release.</summary>
-  /// <param name="mbid">The MusicBrainz release ID for which the image is requested.</param>
-  /// <param name="size">
-  /// The requested image size; <see cref="CoverArtImageSize.Original"/> can be any content type, but the thumbnails are always
-  /// JPEG.
-  /// </param>
   /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
   /// <returns>An asynchronous operation returning the requested image data.</returns>
   /// <exception cref="HttpError">
@@ -63,31 +38,6 @@ public sealed partial class CoverArt {
   public Task<CoverArtImage> FetchBackAsync(Guid mbid, CoverArtImageSize size = CoverArtImageSize.Original,
                                             CancellationToken cancellationToken = new())
     => this.FetchImageAsync("release", mbid, "back", size, cancellationToken);
-
-  /// <summary>Fetch the main "front" image for the specified release, in the specified size.</summary>
-  /// <param name="mbid">The MusicBrainz release ID for which the image is requested.</param>
-  /// <param name="size">
-  /// The requested image size; <see cref="CoverArtImageSize.Original"/> can be any content type, but the thumbnails are always
-  /// JPEG.
-  /// </param>
-  /// <returns>The requested image data.</returns>
-  /// <exception cref="HttpError">
-  /// When the request succeeded but reported an HTTP error status; the most common cases will be:
-  /// <ul><li>
-  ///   404 (<see cref="HttpStatusCode.NotFound"/>) when the release does not exist (or has no "front" image set);
-  /// </li><li>
-  ///   503 (<see cref="HttpStatusCode.ServiceUnavailable"/>) when the server is unavailable, or rate limiting is in effect.
-  /// </li></ul>
-  /// </exception>
-  /// <exception cref="HttpRequestException">
-  /// When the request failed due to an underlying issue such as network connectivity, DNS failure, server certificate validation or
-  /// timeout.
-  /// </exception>
-  /// <exception cref="TaskCanceledException">
-  /// When the request failed due to timeout (.NET Core and .NET 5 and later only).
-  /// </exception>
-  public CoverArtImage FetchFront(Guid mbid, CoverArtImageSize size = CoverArtImageSize.Original)
-    => AsyncUtils.ResultOf(this.FetchFrontAsync(mbid, size));
 
   /// <summary>Fetch the main "front" image for the specified release, in the specified size.</summary>
   /// <param name="mbid">The MusicBrainz release ID for which the image is requested.</param>
@@ -122,31 +72,6 @@ public sealed partial class CoverArt {
   /// The requested image size; <see cref="CoverArtImageSize.Original"/> can be any content type, but the thumbnails are always
   /// JPEG.
   /// </param>
-  /// <returns>The requested image data.</returns>
-  /// <exception cref="HttpError">
-  /// When the request succeeded but reported an HTTP error status; the most common cases will be:
-  /// <ul><li>
-  ///   404 (<see cref="HttpStatusCode.NotFound"/>) when the release group does not exist (or has no "front" image set);
-  /// </li><li>
-  ///   503 (<see cref="HttpStatusCode.ServiceUnavailable"/>) when the server is unavailable, or rate limiting is in effect.
-  /// </li></ul>
-  /// </exception>
-  /// <exception cref="HttpRequestException">
-  /// When the request failed due to an underlying issue such as network connectivity, DNS failure, server certificate validation or
-  /// timeout.
-  /// </exception>
-  /// <exception cref="TaskCanceledException">
-  /// When the request failed due to timeout (.NET Core and .NET 5 and later only).
-  /// </exception>
-  public CoverArtImage FetchGroupFront(Guid mbid, CoverArtImageSize size = CoverArtImageSize.Original)
-    => AsyncUtils.ResultOf(this.FetchGroupFrontAsync(mbid, size));
-
-  /// <summary>Fetch the main "front" image for the specified release group, in the specified size.</summary>
-  /// <param name="mbid">The MusicBrainz release group ID for which the image is requested.</param>
-  /// <param name="size">
-  /// The requested image size; <see cref="CoverArtImageSize.Original"/> can be any content type, but the thumbnails are always
-  /// JPEG.
-  /// </param>
   /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
   /// <returns>An asynchronous operation returning the requested image data.</returns>
   /// <exception cref="HttpError">
@@ -167,28 +92,6 @@ public sealed partial class CoverArt {
   public Task<CoverArtImage> FetchGroupFrontAsync(Guid mbid, CoverArtImageSize size = CoverArtImageSize.Original,
                                                   CancellationToken cancellationToken = new())
     => this.FetchImageAsync("release-group", mbid, "front", size, cancellationToken);
-
-  /// <summary>Fetch information about the cover art associated with the specified MusicBrainz release group (if any).</summary>
-  /// <param name="mbid">The MusicBrainz release group ID for which cover art information is requested.</param>
-  /// <returns>
-  /// An <see cref="IRelease"/> object containing information about the cover art for the release group's main release.
-  /// </returns>
-  /// <exception cref="HttpError">
-  /// When the request succeeded but reported an HTTP error status; the most common cases will be:
-  /// <ul><li>
-  ///   404 (<see cref="HttpStatusCode.NotFound"/>) when the release group does not exist (or has no associated cover art);
-  /// </li><li>
-  ///   503 (<see cref="HttpStatusCode.ServiceUnavailable"/>) when the server is unavailable, or rate limiting is in effect.
-  /// </li></ul>
-  /// </exception>
-  /// <exception cref="HttpRequestException">
-  /// When the request failed due to an underlying issue such as network connectivity, DNS failure, server certificate validation or
-  /// timeout.
-  /// </exception>
-  /// <exception cref="TaskCanceledException">
-  /// When the request failed due to timeout (.NET Core and .NET 5 and later only).
-  /// </exception>
-  public IRelease FetchGroupRelease(Guid mbid) => AsyncUtils.ResultOf(this.FetchGroupReleaseAsync(mbid));
 
   /// <summary>Fetch information about the cover art associated with the specified MusicBrainz release group (if any).</summary>
   /// <param name="mbid">The MusicBrainz release group ID for which cover art information is requested.</param>
@@ -217,25 +120,6 @@ public sealed partial class CoverArt {
 
   /// <summary>Fetch information about the cover art associated with the specified MusicBrainz release group (if any).</summary>
   /// <param name="mbid">The MusicBrainz release group ID for which cover art information is requested.</param>
-  /// <returns>
-  /// An <see cref="IRelease"/> object containing information about the cover art for the release group's main release, or
-  /// <see langword="null"/> if the release group does not exist (or has no associated cover art).
-  /// </returns>
-  /// <exception cref="HttpError">
-  /// When the request succeeded but reported an HTTP error status; the most common case will be status 503
-  /// (<see cref="HttpStatusCode.ServiceUnavailable"/>) when the server is unavailable, or rate limiting is in effect.
-  /// </exception>
-  /// <exception cref="HttpRequestException">
-  /// When the request failed due to an underlying issue such as network connectivity, DNS failure, server certificate validation or
-  /// timeout.
-  /// </exception>
-  /// <exception cref="TaskCanceledException">
-  /// When the request failed due to timeout (.NET Core and .NET 5 and later only).
-  /// </exception>
-  public IRelease? FetchGroupReleaseIfAvailable(Guid mbid) => AsyncUtils.ResultOf(this.FetchGroupReleaseIfAvailableAsync(mbid));
-
-  /// <summary>Fetch information about the cover art associated with the specified MusicBrainz release group (if any).</summary>
-  /// <param name="mbid">The MusicBrainz release group ID for which cover art information is requested.</param>
   /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
   /// <returns>
   /// An asynchronous operation returning an <see cref="IRelease"/> object containing information about the cover art for the
@@ -254,34 +138,6 @@ public sealed partial class CoverArt {
   /// </exception>
   public Task<IRelease?> FetchGroupReleaseIfAvailableAsync(Guid mbid, CancellationToken cancellationToken = new())
     => this.FetchReleaseIfAvailableAsync("release-group", mbid, cancellationToken);
-
-  /// <summary>Fetch the specified image for the specified release, in the specified size.</summary>
-  /// <param name="mbid">The MusicBrainz release ID for which the image is requested.</param>
-  /// <param name="id">
-  /// The ID of the requested image (as found via <see cref="Image.Id"/>, or "front"/"back" as special case).
-  /// </param>
-  /// <param name="size">
-  /// The requested image size; <see cref="CoverArtImageSize.Original"/> can be any content type, but the thumbnails are always
-  /// JPEG.
-  /// </param>
-  /// <returns>The requested image data.</returns>
-  /// <exception cref="HttpError">
-  /// When the request succeeded but reported an HTTP error status; the most common cases will be:
-  /// <ul><li>
-  ///   404 (<see cref="HttpStatusCode.NotFound"/>) when the release and/or the specified image do not exist;
-  /// </li><li>
-  ///   503 (<see cref="HttpStatusCode.ServiceUnavailable"/>) when the server is unavailable, or rate limiting is in effect.
-  /// </li></ul>
-  /// </exception>
-  /// <exception cref="HttpRequestException">
-  /// When the request failed due to an underlying issue such as network connectivity, DNS failure, server certificate validation or
-  /// timeout.
-  /// </exception>
-  /// <exception cref="TaskCanceledException">
-  /// When the request failed due to timeout (.NET Core and .NET 5 and later only).
-  /// </exception>
-  public CoverArtImage FetchImage(Guid mbid, string id, CoverArtImageSize size = CoverArtImageSize.Original)
-    => AsyncUtils.ResultOf(this.FetchImageAsync(mbid, id, size));
 
   /// <summary>Fetch the specified image for the specified release, in the specified size.</summary>
   /// <param name="mbid">The MusicBrainz release ID for which the image is requested.</param>
@@ -315,26 +171,6 @@ public sealed partial class CoverArt {
 
   /// <summary>Fetch information about the cover art associated with the specified MusicBrainz release (if any).</summary>
   /// <param name="mbid">The MusicBrainz release ID for which cover art information is requested.</param>
-  /// <returns>An <see cref="IRelease"/> object containing information about the cover art for the release.</returns>
-  /// <exception cref="HttpError">
-  /// When the request succeeded but reported an HTTP error status; the most common cases will be:
-  /// <ul><li>
-  ///   404 (<see cref="HttpStatusCode.NotFound"/>) when the release does not exist (or has no associated cover art);
-  /// </li><li>
-  ///   503 (<see cref="HttpStatusCode.ServiceUnavailable"/>) when the server is unavailable, or rate limiting is in effect.
-  /// </li></ul>
-  /// </exception>
-  /// <exception cref="HttpRequestException">
-  /// When the request failed due to an underlying issue such as network connectivity, DNS failure, server certificate validation or
-  /// timeout.
-  /// </exception>
-  /// <exception cref="TaskCanceledException">
-  /// When the request failed due to timeout (.NET Core and .NET 5 and later only).
-  /// </exception>
-  public IRelease FetchRelease(Guid mbid) => AsyncUtils.ResultOf(this.FetchReleaseAsync(mbid));
-
-  /// <summary>Fetch information about the cover art associated with the specified MusicBrainz release (if any).</summary>
-  /// <param name="mbid">The MusicBrainz release ID for which cover art information is requested.</param>
   /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
   /// <returns>
   /// An asynchronous operation returning an <see cref="IRelease"/> object containing information about the cover art for the
@@ -357,25 +193,6 @@ public sealed partial class CoverArt {
   /// </exception>
   public Task<IRelease> FetchReleaseAsync(Guid mbid, CancellationToken cancellationToken = new())
     => this.FetchReleaseAsync("release", mbid, cancellationToken);
-
-  /// <summary>Fetch information about the cover art associated with the specified MusicBrainz release (if any).</summary>
-  /// <param name="mbid">The MusicBrainz release ID for which cover art information is requested.</param>
-  /// <returns>
-  /// An <see cref="IRelease"/> object containing information about the cover art for the release, or <see langword="null"/> if
-  /// the release does not exist (or has no associated cover art).
-  /// </returns>
-  /// <exception cref="HttpError">
-  /// When the request succeeded but reported an HTTP error status; the most common case will be status 503
-  /// (<see cref="HttpStatusCode.ServiceUnavailable"/>) when the server is unavailable, or rate limiting is in effect.
-  /// </exception>
-  /// <exception cref="HttpRequestException">
-  /// When the request failed due to an underlying issue such as network connectivity, DNS failure, server certificate validation or
-  /// timeout.
-  /// </exception>
-  /// <exception cref="TaskCanceledException">
-  /// When the request failed due to timeout (.NET Core and .NET 5 and later only).
-  /// </exception>
-  public IRelease? FetchReleaseIfAvailable(Guid mbid) => AsyncUtils.ResultOf(this.FetchReleaseIfAvailableAsync(mbid));
 
   /// <summary>Fetch information about the cover art associated with the specified MusicBrainz release (if any).</summary>
   /// <param name="mbid">The MusicBrainz release ID for which cover art information is requested.</param>

--- a/MetaBrainz.MusicBrainz.CoverArt/Interfaces/IImage.cs
+++ b/MetaBrainz.MusicBrainz.CoverArt/Interfaces/IImage.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 
 using JetBrains.Annotations;
 
@@ -11,10 +12,10 @@ namespace MetaBrainz.MusicBrainz.CoverArt.Interfaces;
 [PublicAPI]
 public interface IImage : IJsonBasedObject {
 
-  /// <summary>Flag indicating whether or not the image is approved.</summary>
+  /// <summary>Flag indicating whether the image is approved.</summary>
   bool Approved { get; }
 
-  /// <summary>Flag indicating whether or not this is the image marked as the main "back" image for a release.</summary>
+  /// <summary>Flag indicating whether this is the image marked as the main "back" image for a release.</summary>
   bool Back { get; }
 
   /// <summary>The comment attached to the image, if any.</summary>
@@ -24,10 +25,13 @@ public interface IImage : IJsonBasedObject {
   /// <remarks>For more information about that edit, go to http://musicbrainz.org/edit/{edit-id}.</remarks>
   int Edit { get; }
 
-  /// <summary>Flag indicating whether or not this is the image marked as the main "front" image for a release.</summary>
+  /// <summary>Flag indicating whether this is the image marked as the main "front" image for a release.</summary>
   bool Front { get; }
 
-  /// <summary>The internal ID of the image. Can be used in a call to <see cref="CoverArt.FetchImage(Guid,string,CoverArtImageSize)"/>.</summary>
+  /// <summary>
+  /// The internal ID of the image.
+  /// This can be used in a call to <see cref="CoverArt.FetchImageAsync(Guid,string,CoverArtImageSize,CancellationToken)"/>.
+  /// </summary>
   /// <remarks>This ID is determined and set when the image is uploaded, and will never change.</remarks>
   string Id { get; }
 

--- a/MetaBrainz.MusicBrainz.CoverArt/MetaBrainz.MusicBrainz.CoverArt.csproj
+++ b/MetaBrainz.MusicBrainz.CoverArt/MetaBrainz.MusicBrainz.CoverArt.csproj
@@ -14,7 +14,7 @@
     <PackageCopyrightYears>2016-2025</PackageCopyrightYears>
     <PackageRepositoryName>MetaBrainz.MusicBrainz.CoverArt</PackageRepositoryName>
     <PackageTags>MusicBrainz album cover art archive CAA libcoverart</PackageTags>
-    <Version>6.0.1-pre</Version>
+    <Version>7.0.0-pre</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/public-api/MetaBrainz.MusicBrainz.CoverArt.net8.0.cs.md
+++ b/public-api/MetaBrainz.MusicBrainz.CoverArt.net8.0.cs.md
@@ -88,35 +88,19 @@ public sealed class CoverArt : System.IDisposable {
 
   public sealed override void Dispose();
 
-  public CoverArtImage FetchBack(System.Guid mbid, CoverArtImageSize size = CoverArtImageSize.Original);
-
   public System.Threading.Tasks.Task<CoverArtImage> FetchBackAsync(System.Guid mbid, CoverArtImageSize size = CoverArtImageSize.Original, System.Threading.CancellationToken cancellationToken = default);
-
-  public CoverArtImage FetchFront(System.Guid mbid, CoverArtImageSize size = CoverArtImageSize.Original);
 
   public System.Threading.Tasks.Task<CoverArtImage> FetchFrontAsync(System.Guid mbid, CoverArtImageSize size = CoverArtImageSize.Original, System.Threading.CancellationToken cancellationToken = default);
 
-  public CoverArtImage FetchGroupFront(System.Guid mbid, CoverArtImageSize size = CoverArtImageSize.Original);
-
   public System.Threading.Tasks.Task<CoverArtImage> FetchGroupFrontAsync(System.Guid mbid, CoverArtImageSize size = CoverArtImageSize.Original, System.Threading.CancellationToken cancellationToken = default);
-
-  public MetaBrainz.MusicBrainz.CoverArt.Interfaces.IRelease FetchGroupRelease(System.Guid mbid);
 
   public System.Threading.Tasks.Task<MetaBrainz.MusicBrainz.CoverArt.Interfaces.IRelease> FetchGroupReleaseAsync(System.Guid mbid, System.Threading.CancellationToken cancellationToken = default);
 
-  public MetaBrainz.MusicBrainz.CoverArt.Interfaces.IRelease? FetchGroupReleaseIfAvailable(System.Guid mbid);
-
   public System.Threading.Tasks.Task<MetaBrainz.MusicBrainz.CoverArt.Interfaces.IRelease?> FetchGroupReleaseIfAvailableAsync(System.Guid mbid, System.Threading.CancellationToken cancellationToken = default);
-
-  public CoverArtImage FetchImage(System.Guid mbid, string id, CoverArtImageSize size = CoverArtImageSize.Original);
 
   public System.Threading.Tasks.Task<CoverArtImage> FetchImageAsync(System.Guid mbid, string id, CoverArtImageSize size = CoverArtImageSize.Original, System.Threading.CancellationToken cancellationToken = default);
 
-  public MetaBrainz.MusicBrainz.CoverArt.Interfaces.IRelease FetchRelease(System.Guid mbid);
-
   public System.Threading.Tasks.Task<MetaBrainz.MusicBrainz.CoverArt.Interfaces.IRelease> FetchReleaseAsync(System.Guid mbid, System.Threading.CancellationToken cancellationToken = default);
-
-  public MetaBrainz.MusicBrainz.CoverArt.Interfaces.IRelease? FetchReleaseIfAvailable(System.Guid mbid);
 
   public System.Threading.Tasks.Task<MetaBrainz.MusicBrainz.CoverArt.Interfaces.IRelease?> FetchReleaseIfAvailableAsync(System.Guid mbid, System.Threading.CancellationToken cancellationToken = default);
 


### PR DESCRIPTION
It is up to the end user to decide how to make use of the async methods.

The non-async versions essentially only added `.ConfigureAwait(false).GetAwaiter().GetResult()` to the main async implementation (via `AsyncUtils.ValueOf()`).

Bumping version to 7.0.0-pre because this is obviously a breaking change.